### PR TITLE
Cr 423 read rabbit config as stream

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>event-publisher</artifactId>
-      <version>0.0.10-SNAPSHOT</version>
+      <version>0.0.10</version>
     </dependency>
     
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>event-publisher</artifactId>
-      <version>0.0.9</version>
+      <version>0.0.10-SNAPSHOT</version>
     </dependency>
     
     <dependency>

--- a/src/main/resources/rabbitmq.yml
+++ b/src/main/resources/rabbitmq.yml
@@ -1,4 +1,4 @@
-rabbitmq:
+cucumberrabbitmq:
   username: guest
   password: guest
   host: localhost


### PR DESCRIPTION
Rabbit config renamed at the top level, so that overriding its fields can be done with a new set of environment variables.
This change is needed because there were an existing (and incorrect) set of rabbitmq environment variables.