### PR TITLE
update pom to point to version 0.0.16 of event publisher to fix Objec…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>event-publisher</artifactId>
-      <version>0.0.14</version>
+      <version>0.0.16</version>
     </dependency>
   </dependencies>
     


### PR DESCRIPTION
Updated pom to point to version 0.0.16 of event publisher to fix ObjectMapper error.