### PR TITLE
Add TimeoutParser utility as this is now used by both RH CUC and CC CUC

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/common/util/TimeoutParser.java
+++ b/src/main/java/uk/gov/ons/ctp/common/util/TimeoutParser.java
@@ -1,0 +1,39 @@
+package uk.gov.ons.ctp.common.util;
+
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.common.error.CTPException.Fault;
+
+public class TimeoutParser {
+  private static final Logger log = LoggerFactory.getLogger(TimeoutParser.class);
+
+  /**
+   * Converts a string time specification into a milliseconds value. This method assumes a time in
+   * the format of "[digits]ms|s", eg 500ms, 2s, 2.5s.
+   *
+   * @param timeout is a String specifying the time value.
+   * @return long containing the number of milliseconds this time period represents.
+   * @throws CTPException if the timeout string doesn't end with 'ms' or 's'.
+   */
+  public static long parseTimeoutString(String timeout) throws CTPException {
+    int multiplier;
+    if (timeout.endsWith("ms")) {
+      multiplier = 1;
+    } else if (timeout.endsWith("s")) {
+      multiplier = 1000;
+    } else {
+      String errorMessage =
+          "timeout specification ('"
+              + timeout
+              + "') must end with either 'ms' for milliseconds or 's' for seconds";
+      log.error(errorMessage);
+      throw new CTPException(Fault.VALIDATION_FAILED, errorMessage);
+    }
+
+    String timeoutValue = timeout.replaceAll("(ms|s)", "");
+
+    double timeoutAsDouble = Double.parseDouble(timeoutValue) * multiplier;
+    return (long) timeoutAsDouble;
+  }
+}


### PR DESCRIPTION
I have added the TimeoutParser utility as this is now required for the CR-771 scenarios, which I am currently writing in the census-contact-centre-cucumber. NB. The TimeoutParser utility also currently exists in census-rh-cucumber so that will need to be amended to use the one in this common repo instead of having a local one.