### PR TITLE
Cr 935 common firestore

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,12 +70,20 @@
       <artifactId>jsoup</artifactId>
       <version>1.12.1</version>
     </dependency>
-
+    <!-- ONS dependencies start -->
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>framework</artifactId>
       <version>0.0.62</version>
     </dependency>
+
+    <dependency>
+      <groupId>uk.gov.ons.ctp.integration.common</groupId>
+      <artifactId>test-framework</artifactId>
+      <version>0.0.17</version>
+    </dependency>
+
+    <!-- ONS dependencies end -->
 
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -71,14 +71,12 @@
       <version>1.12.1</version>
     </dependency>
 
-
-    <!-- ONS libraries -->
-
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
-      <artifactId>event-publisher</artifactId>
-      <version>0.0.40</version>
+      <artifactId>framework</artifactId>
+      <version>0.0.62</version>
     </dependency>
+
   </dependencies>
 
   <build>

--- a/src/main/java/uk/gov/ons/ctp/common/cloud/TestCloudDataStore.java
+++ b/src/main/java/uk/gov/ons/ctp/common/cloud/TestCloudDataStore.java
@@ -11,7 +11,7 @@ import uk.gov.ons.ctp.common.error.CTPException;
 @Component
 public class TestCloudDataStore implements CloudDataStore {
 
-  @Autowired private CloudDataStore cloudDataStore;
+  @Autowired private FirestoreDataStore cloudDataStore;
 
   @Override
   public void deleteObject(String schema, String key) throws CTPException {

--- a/src/main/java/uk/gov/ons/ctp/common/cloud/TestCloudDataStore.java
+++ b/src/main/java/uk/gov/ons/ctp/common/cloud/TestCloudDataStore.java
@@ -1,0 +1,46 @@
+package uk.gov.ons.ctp.common.cloud;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.gov.ons.ctp.common.error.CTPException;
+
+/** Access the Cloud data store for testing purposes. */
+@Component
+public class TestCloudDataStore implements CloudDataStore {
+
+  @Autowired private CloudDataStore cloudDataStore;
+
+  @Override
+  public void deleteObject(String schema, String key) throws CTPException {
+    cloudDataStore.deleteObject(schema, key);
+  }
+
+  @Override
+  public Set<String> getCollectionNames() {
+    return cloudDataStore.getCollectionNames();
+  }
+
+  @Override
+  public <T> Optional<T> retrieveObject(Class<T> target, String schema, String key)
+      throws CTPException {
+    return cloudDataStore.retrieveObject(target, schema, key);
+  }
+
+  @Override
+  public <T> List<T> search(Class<T> target, String schema, String[] fieldPath, String searchValue)
+      throws CTPException {
+    return cloudDataStore.search(target, schema, fieldPath, searchValue);
+  }
+
+  @Override
+  public void storeObject(String schema, String key, Object value) throws CTPException {
+    try {
+      cloudDataStore.storeObject(schema, key, value);
+    } catch (DataStoreContentionException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/main/java/uk/gov/ons/ctp/common/cloud/TestCloudDataStore.java
+++ b/src/main/java/uk/gov/ons/ctp/common/cloud/TestCloudDataStore.java
@@ -33,11 +33,11 @@ public class TestCloudDataStore implements CloudDataStore {
     CollectionReference collection = firestore.collection(schema);
 
     long totalDeleted = 0;
-    int batchDeleted = 0;
+    int numDeletedInBatch = 0;
     do {
-      batchDeleted = deleteBatch(collection);
-      totalDeleted += batchDeleted;
-    } while (batchDeleted >= DELETION_BATCH_SIZE);
+      numDeletedInBatch = deleteBatch(collection);
+      totalDeleted += numDeletedInBatch;
+    } while (numDeletedInBatch >= DELETION_BATCH_SIZE);
 
     return totalDeleted;
   }

--- a/src/main/java/uk/gov/ons/ctp/common/cloud/TestCloudDataStore.java
+++ b/src/main/java/uk/gov/ons/ctp/common/cloud/TestCloudDataStore.java
@@ -6,41 +6,55 @@ import java.util.Set;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.common.firestore.FirestoreWait;
 
 /** Access the Cloud data store for testing purposes. */
 @Component
 public class TestCloudDataStore implements CloudDataStore {
 
-  @Autowired private FirestoreDataStore cloudDataStore;
+  @Autowired private FirestoreDataStore dataStore;
 
   @Override
   public void deleteObject(String schema, String key) throws CTPException {
-    cloudDataStore.deleteObject(schema, key);
+    dataStore.deleteObject(schema, key);
   }
 
   @Override
   public Set<String> getCollectionNames() {
-    return cloudDataStore.getCollectionNames();
+    return dataStore.getCollectionNames();
   }
 
   @Override
   public <T> Optional<T> retrieveObject(Class<T> target, String schema, String key)
       throws CTPException {
-    return cloudDataStore.retrieveObject(target, schema, key);
+    return dataStore.retrieveObject(target, schema, key);
   }
 
   @Override
   public <T> List<T> search(Class<T> target, String schema, String[] fieldPath, String searchValue)
       throws CTPException {
-    return cloudDataStore.search(target, schema, fieldPath, searchValue);
+    return dataStore.search(target, schema, fieldPath, searchValue);
   }
 
   @Override
   public void storeObject(String schema, String key, Object value) throws CTPException {
     try {
-      cloudDataStore.storeObject(schema, key, value);
+      dataStore.storeObject(schema, key, value);
     } catch (DataStoreContentionException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  public boolean waitForObject(String collection, String key, long timeoutMillis)
+      throws CTPException {
+
+    if (collection == null || key == null) {
+      throw new IllegalArgumentException("collection and key must be provided");
+    }
+
+    FirestoreWait firestore =
+        FirestoreWait.builder().collection(collection).key(key).timeout(timeoutMillis).build();
+
+    return firestore.waitForObject() != null;
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/common/cloud/TestCloudDataStore.java
+++ b/src/main/java/uk/gov/ons/ctp/common/cloud/TestCloudDataStore.java
@@ -1,8 +1,15 @@
 package uk.gov.ons.ctp.common.cloud;
 
+import com.google.api.core.ApiFuture;
+import com.google.cloud.firestore.CollectionReference;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.FirestoreOptions;
+import com.google.cloud.firestore.QueryDocumentSnapshot;
+import com.google.cloud.firestore.QuerySnapshot;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import javax.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.ons.ctp.common.error.CTPException;
@@ -11,8 +18,29 @@ import uk.gov.ons.ctp.common.firestore.FirestoreWait;
 /** Access the Cloud data store for testing purposes. */
 @Component
 public class TestCloudDataStore implements CloudDataStore {
+  private static final int DELETION_BATCH_SIZE = 100;
 
   @Autowired private FirestoreDataStore dataStore;
+
+  private Firestore firestore;
+
+  @PostConstruct
+  public void create() {
+    firestore = FirestoreOptions.getDefaultInstance().getService();
+  }
+
+  public long deleteCollection(String schema) {
+    CollectionReference collection = firestore.collection(schema);
+
+    long totalDeleted = 0;
+    int batchDeleted = 0;
+    do {
+      batchDeleted = deleteBatch(collection);
+      totalDeleted += batchDeleted;
+    } while (batchDeleted >= DELETION_BATCH_SIZE);
+
+    return totalDeleted;
+  }
 
   @Override
   public void deleteObject(String schema, String key) throws CTPException {
@@ -56,5 +84,21 @@ public class TestCloudDataStore implements CloudDataStore {
         FirestoreWait.builder().collection(collection).key(key).timeout(timeoutMillis).build();
 
     return firestore.waitForObject() != null;
+  }
+
+  // there is no firestore method to delete a collection, so we delete in batches.
+  private int deleteBatch(CollectionReference collection) {
+    int deleted = 0;
+    try {
+      ApiFuture<QuerySnapshot> future = collection.limit(DELETION_BATCH_SIZE).get();
+      List<QueryDocumentSnapshot> documents = future.get().getDocuments();
+      for (QueryDocumentSnapshot document : documents) {
+        document.getReference().delete();
+        ++deleted;
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    return deleted;
   }
 }


### PR DESCRIPTION
A test specific firestore access class has been created for a one-stop shop for cucumber firestore operations which:

- delegates in most instances to the framework firestore component
- exposes the delete object method
- introduces a delete entire collection method , based on example code on googles web page . This is in anticipation that the cucumber code may want to use it in the future to "start clean". 
- adds a waitForObject method that replaces and simplifies the FirestoreUtils class code.

The adapted RH cucumber and CC cucumber code  has been tested with the new code, without the need for duplicated firestore access code in those projects.
